### PR TITLE
fix(removables) added initial redraw to restore state

### DIFF
--- a/src/js/components/slide/removable.js
+++ b/src/js/components/slide/removable.js
@@ -180,7 +180,6 @@ class Removables {
     _.each(this.removables, removable => {
       removable.hidden = !removableState[removable.key] || false;
     });
-    console.log({ removableState });
     this.onUpdate();
   };
 

--- a/src/js/components/slide/removable.js
+++ b/src/js/components/slide/removable.js
@@ -160,6 +160,9 @@ class Removables {
       this.state.update({
         removables: initialState
       });
+    } else {
+      // restore saved state
+      this.updateRemovables(state);
     }
 
     this.restoreButton.addEventListener('click', () => {
@@ -177,6 +180,7 @@ class Removables {
     _.each(this.removables, removable => {
       removable.hidden = !removableState[removable.key] || false;
     });
+    console.log({ removableState });
     this.onUpdate();
   };
 


### PR DESCRIPTION
I noticed this when reviewing Loz' PR - removables disappear when UI (remove) buttons are clicked, but the removeable states are not restored when returning to the slide, until another remove button is clicked.